### PR TITLE
Removed `PartitionKey` from the signature of `handleRequest`. ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,14 @@ The Legion framework is still experimental.
 
 ### Examples
 
-Check out the [legion-cache](https://github.com/taphu/legion-cache) project for
-an example of how to build a basic distributed key-value store with legion.
+Check out the
+[legion-discovery](https://github.com/owensmurray/legion-discovery)
+project for an example of a stateful web services that advantage of
+Legion's ability to define your own operations on your data. Take a look at
+[`Network.Legion.Discovery.App`](https://github.com/owensmurray/legion-discovery/blob/master/src/Network/Legion/Discovery/App.hs)
+to see where the magic of defining a Legion application happens. The rest
+of the code is mostly just standard HTTP-interface-written-in-Haskell,
+and requests sent to the Legion runtime.
 
 ## FAQ
 

--- a/legion.cabal
+++ b/legion.cabal
@@ -6,11 +6,11 @@ version:             0.4.0.0
 synopsis:            Distributed, stateful, homogeneous microservice framework.
 description:         Legion is a framework for writing distributed,
                      homogeneous, stateful microservices in Haskell.
-homepage:            https://github.com/taphu/legion
+homepage:            https://github.com/owensmurray/legion#readme
 license:             Apache-2.0
 license-file:        LICENSE
 author:              Rick Owens
-maintainer:          rick@owenssoftware.com
+maintainer:          rick@owensmurray.com
 copyright:           2015-2016 Rick Owens
 category:            Concurrency, Network
 stability:           experimental
@@ -20,7 +20,7 @@ cabal-version:       >=1.10
 
 source-repository head
   type: git
-  location: git@github.com:taphu/legion.git
+  location: git@github.com:owensmurray/legion.git
 
 library
   exposed-modules:

--- a/legion.cabal
+++ b/legion.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                legion
-version:             0.4.0.0
+version:             0.5.0.0
 synopsis:            Distributed, stateful, homogeneous microservice framework.
 description:         Legion is a framework for writing distributed,
                      homogeneous, stateful microservices in Haskell.

--- a/src/Network/Legion.hs
+++ b/src/Network/Legion.hs
@@ -194,9 +194,13 @@ import Network.Legion.Settings (RuntimeSettings(RuntimeSettings,
 
 -- $startup
 -- While this section is being worked on, you can check out the
--- [legion-cache](https://github.com/taphu/legion-cache) project for a
--- working example of how to build a basic distributed key-value store
--- using Legion.
+-- [legion-discovery](https://github.com/owensmurray/legion-discovery)
+-- project for an example of a stateful web services that advantage of
+-- Legion's ability to define your own operations on your data. Take a look at
+-- [`Network.Legion.Discovery.App`](https://github.com/owensmurray/legion-discovery/blob/master/src/Network/Legion/Discovery/App.hs)
+-- to see where the magic of defining a Legion application happens. The rest
+-- of the code is mostly just standard HTTP-interface-written-in-Haskell,
+-- and requests sent to the Legion runtime.
 
 --------------------------------------------------------------------------------
 

--- a/src/Network/Legion/Application.hs
+++ b/src/Network/Legion/Application.hs
@@ -51,7 +51,7 @@ data Legionary i o s = Legionary {
 
       Given a request and a state, returns a response to the request.
     -}
-    handleRequest :: PartitionKey -> i -> s -> o,
+    handleRequest :: i -> s -> o,
 
     {- | The user-defined persistence layer implementation. -}
     persistence :: Persistence i s,

--- a/src/Network/Legion/StateMachine.hs
+++ b/src/Network/Legion/StateMachine.hs
@@ -181,7 +181,7 @@ userRequest key request = SM $ do
     then do
       partition <- unSM $ getPartition key
       let
-        response = handleRequest key request (P.ask partition)
+        response = handleRequest request (P.ask partition)
         partition2 = P.delta request partition
       unSM $ savePartition key partition2
       return (Respond response)

--- a/src/Network/Legion/StateMachine.hs
+++ b/src/Network/Legion/StateMachine.hs
@@ -325,7 +325,13 @@ rebalance = SM $ do
   (lift . put) ns {
       cluster = case action of
         Nothing -> cluster
-        Just (Invite ks) -> C.claimParticipation self ks cluster
+        Just (Invite ks) ->
+          {-
+            This 'claimParticipation' will be enforced by the remote
+            peers, because those peers will see the change in distribution
+            and then perform a 'migrate'.
+          -}
+          C.claimParticipation self ks cluster
     }
 
 


### PR DESCRIPTION
Having the partition key available as an input to the request handler has
turned out to be completely useless in every case so far.  The request
handler is responsible for implementing the application business logic,
whereas the partition key is strictly a Legion concern. Therefore, in
addition to being useless, it is probably actually a very bad thing to
allow the business logic to have access to this information.  Therefore,
I am removing it from the interface.